### PR TITLE
Improve instantiated-app workflow (post greenfield feedback)

### DIFF
--- a/.cursor/commands/code_review.md
+++ b/.cursor/commands/code_review.md
@@ -44,7 +44,7 @@ If not specified, review all uncommitted changes.
 - [ ] No unnecessary complexity
 - [ ] Separation of concerns maintained
 - [ ] Dependencies are appropriate
-- [ ] **Backend parity:** Both `server.js` AND `functions/index.js` updated (if API changes)
+- [ ] **Backend parity:** All entry points in `docs/ARCHITECTURE.md` updated; shared handlers used (if API changes)
 
 ### 4. Code Quality
 

--- a/.cursor/commands/create_plan.md
+++ b/.cursor/commands/create_plan.md
@@ -100,48 +100,40 @@ Conversion Required:
 
 ## Backend File Mapping (REQUIRED for backend changes)
 
-**CRITICAL:** Any backend API or logic changes MUST be applied to ALL backend files.
+**Do not assume a fixed file pair** (e.g. `server.js` + `functions/index.js`). Each project defines its own entry points.
 
-Before writing the execution plan, identify ALL backend entry points:
+Before writing the execution plan:
 
-| Environment | File | Deployment |
-|-------------|------|------------|
-| Local Dev | `server.js` | `npm run dev` |
-| Production | `functions/index.js` | `firebase deploy --only functions` |
+1. Create or update **`docs/ARCHITECTURE.md`** from [docs/ARCHITECTURE_TEMPLATE.md](docs/ARCHITECTURE_TEMPLATE.md).
+2. List **every** environment that serves HTTP (local dev, production, preview, CI).
+3. Prefer **one shared router/handler module** imported by all entry points.
 
-**Checklist Template:**
+**Checklist template:**
 ```
-### Backend Changes (apply to BOTH files)
-- [ ] Update server.js (local dev)
-- [ ] Update functions/index.js (production)
-- [ ] Test locally via server.js
-- [ ] Deploy functions to production
-- [ ] Verify production behavior
+### Backend changes
+- [ ] Update shared handlers (single source of truth)
+- [ ] Update each entry point listed in docs/ARCHITECTURE.md
+- [ ] Local smoke test (document URL, e.g. curl …/health)
+- [ ] Production path check: web client base URL matches hosting rewrites
+- [ ] Deploy and verify production (if applicable)
 ```
 
-See `docs/ARCHITECTURE.md` for full architecture details.
+## Bootable milestone (greenfield plans)
 
-## Local Development Parity (if adding API endpoints)
+For new apps, split the execution plan:
 
-If adding new API endpoints, include checklist items for both:
-- `functions/index.js` (Firebase Cloud Functions)
-- `server.js` (local development server)
+1. **Milestone A — Bootable:** auth (if any), health/smoke endpoint, empty shell UI, `.env` documented, one vertical slice testable locally.
+2. **Milestone B+ — Features:** remaining plan phases.
 
-Both files must have:
-- Same endpoint routes
-- Same helper functions
-- Same error handling
+Include **First run verification** checklist in Milestone A:
+- [ ] All start commands documented
+- [ ] One authenticated or public API call succeeds
+- [ ] No unhandled promise rejections / server crashes on happy path
 
-Example:
-```
-### Backend
-- [ ] Add endpoint to functions/index.js
-- [ ] Add endpoint to server.js (for local dev)
-- [ ] Add helper function X to functions/index.js
-- [ ] Add helper function X to server.js
-- [ ] Test endpoint locally via server.js
-- [ ] Deploy functions: firebase deploy --only functions --project epiphoric-prod
-```
+Include **Production path check** before calling MVP done:
+- [ ] Web build API base URL correct for hosted deploy
+- [ ] Hosting rewrites / API mount paths aligned
+- [ ] Firestore rules / secrets / CORS documented
 
 # Acceptance Criteria (if `last_explore.md` exists)
 Include acceptance criteria from exploration or derive from Success Criteria.

--- a/.cursor/commands/design_decisions.md
+++ b/.cursor/commands/design_decisions.md
@@ -50,10 +50,26 @@ If using React:
 - Specify use of functional updates: `setState(prev => ...)` where needed
 - Reference `docs/REACT_PATTERNS.md` for patterns
 
-### 7. Local Development Parity
+### 7. Backend entry points & parity
+
 If adding API endpoints:
-- Plan to update both `functions/index.js` and `server.js`
-- Document which helper functions need to be duplicated
+
+- Create/update **`docs/ARCHITECTURE.md`** (from [ARCHITECTURE_TEMPLATE.md](docs/ARCHITECTURE_TEMPLATE.md))
+- List every HTTP entry point (local, production, preview)
+- Prefer one shared handler module imported by all entry points — avoid duplicating route tables
+- Document web client → API base URL for local and production builds
+
+### 8. Integrations & dev environment
+
+For auth, payments, email, or third-party APIs, document:
+
+- **Sandbox vs production** credentials and env vars
+- **Auth UX by environment** (e.g. OAuth popup on localhost vs redirect on hosted domain)
+- **Required one-time deploys** (e.g. hosting for auth helper, webhooks)
+- **Emulator / seed commands** and ports
+- **SSH or remote dev** constraints (authorized domains, port forwarding)
+
+Copy [DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` and add rows as you learn.
 
 Rules:
 - Favor reversible decisions

--- a/.cursor/commands/execute_plan.md
+++ b/.cursor/commands/execute_plan.md
@@ -29,7 +29,7 @@ Rules:
 - Do not introduce new scope
 - Do not refactor unrelated code
 - If you discover missing information, pause and ask
-- **When adding API endpoints: Update both `functions/index.js` AND `server.js`**
+- **When adding API endpoints:** Update every entry point in `docs/ARCHITECTURE.md`; prefer shared handlers over duplicated route files
 
 Process:
 - Implement one step at a time
@@ -43,7 +43,7 @@ Process:
   - Avoid decisions that contradict stated constraints
 
 **Special Checks:**
-- **API Endpoints:** When adding new endpoints, verify both `functions/index.js` and `server.js` are updated
+- **API Endpoints:** Shared handlers + all entry points in `docs/ARCHITECTURE.md` updated
 - **Data Formats:** When transforming data, verify format conversions match documented specs
 - **React State:** When updating state that depends on props/state, use functional updates
 - **Content Rendering:** If adding formatted content, implement rendering strategy from design decisions

--- a/.cursor/commands/explore.md
+++ b/.cursor/commands/explore.md
@@ -12,9 +12,9 @@ Steps (in THIS response):
 4. Identify what success looks like
 5. List constraints and risks
 6. **Architecture Check** (if backend/API changes):
-   - Identify ALL backend entry points (server.js, functions/index.js, etc.)
+   - Identify ALL backend entry points (document in `docs/ARCHITECTURE.md` — do not assume fixed filenames)
    - Document which environments each serves (local dev vs production)
-   - Note if changes must be applied to multiple files for parity
+   - Note whether a shared handler module should be updated once vs many entry points
 7. Ask clarifying questions that materially affect planning or execution
 
 Rules:

--- a/.cursor/commands/pre_implementation_checklist.md
+++ b/.cursor/commands/pre_implementation_checklist.md
@@ -66,17 +66,16 @@ tags → tags → merge → tag names → tag IDs
 
 ---
 
-### 4. Local Development Parity
+### 4. Backend entry points
 
 If adding new API endpoints:
 
-- [ ] Plan includes updates to both:
-  - `functions/index.js` (Firebase Functions)
-  - `server.js` (local development server)
-- [ ] Helper functions that need to be duplicated are identified
-- [ ] Local dev testing strategy is defined
+- [ ] **`docs/ARCHITECTURE.md`** exists and lists every HTTP entry point
+- [ ] Plan updates **shared handlers** first, then each entry point that mounts them
+- [ ] Local smoke test URL documented (e.g. health check path including any `/api` prefix)
+- [ ] Production web → API base URL documented
 
-**Action:** Add checklist items to execution plan for both files
+**Action:** Use [ARCHITECTURE_TEMPLATE.md](docs/ARCHITECTURE_TEMPLATE.md) if missing
 
 **Next Step:** Continue to step 5.
 

--- a/.cursor/commands/workflow.md
+++ b/.cursor/commands/workflow.md
@@ -1,6 +1,8 @@
-# Epiphoric Development Workflow
+# Application Development Workflow (Project Genesis)
 
-This document outlines the recommended workflow for implementing features in Epiphoric.
+This document outlines the recommended workflow for building features in a **Genesis-instantiated application** (your product repo). It is copied from [Project Genesis](https://github.com/Leftyshields/project-genesis) via `instantiate.sh` — **customize** backend paths and doc links for your stack after instantiating.
+
+See also: [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
 
 ---
 
@@ -54,13 +56,13 @@ This document outlines the recommended workflow for implementing features in Epi
 6. **Execute Plan** (`/execute_plan`)
    - Follow the execution plan step-by-step
    - Reference design decisions for guidance
-   - Update both `functions/index.js` AND `server.js` for new endpoints
+   - Apply backend changes to **all documented entry points** (see `docs/ARCHITECTURE.md`)
    - Use functional state updates when updating state based on props/state
    - Implement format conversions as documented
    
    **Optional:** Run `/tdd` for complex logic (test-driven development)
    
-   **Next:** Run `/code_review` for automated review, then `/qa_checklist` for manual testing
+   **Required before next feature:** Run `/code_review`, then `/qa_checklist` (do not skip after MVP milestones)
 
 ---
 
@@ -164,24 +166,35 @@ For smaller changes or bug fixes:
 
 ---
 
+## After instantiating a new project
+
+1. Copy [docs/ARCHITECTURE_TEMPLATE.md](docs/ARCHITECTURE_TEMPLATE.md) → `docs/ARCHITECTURE.md` and fill in entry points.
+2. Copy [docs/DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` as you debug.
+3. Add a **“This repo”** subsection below with your backend paths and runbook link.
+4. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
+
+---
+
 ## ⚠️ Common Mistakes to Avoid
 
 1. **Skipping Design Decisions** - Always run `/design_decisions` before implementation
-2. **Forgetting Local Dev Parity** - Always update both `functions/index.js` and `server.js`
-3. **Stale Closures** - Use functional state updates when updating state based on props/state
-4. **Missing Format Conversions** - Document and implement all format conversions
-5. **Skipping Pre-Implementation Checklist** - Verify all requirements before coding
-6. **Forgetting to stage before commit** - Run `git add -A` (or `git add .`) before `git commit` when you want to include current changes; otherwise the commit can be empty and `git push` will report everything up-to-date
+2. **Forgetting backend parity** - Document all HTTP entry points in `docs/ARCHITECTURE.md`; update every entry point that mounts your API router (not a fixed pair of filenames)
+3. **Skipping MVP QA gate** - After `/execute_plan` on a milestone, run `/qa_checklist` and `/code_review` before the next `/capture_issue`
+4. **Confusing product mission with `.genome/mission.md`** - App goals live in capture/plan/closure docs; genome mission is framework metadata
+5. **Stale Closures** - Use functional state updates when updating state based on props/state
+6. **Missing Format Conversions** - Document and implement all format conversions
+7. **Skipping Pre-Implementation Checklist** - Verify all requirements before coding
+8. **Forgetting to stage before commit** - Run `git add -A` before `git commit` when shipping changes
 
 ---
 
-## 📚 Related Documentation
+## 📚 Related Documentation (templates — copy into your app repo)
 
-- [Data Format Reference](docs/DATA_FORMAT_REFERENCE.md) - Data structure specs
-- [React Patterns](docs/REACT_PATTERNS.md) - React best practices
-- [API Endpoints](docs/API_ENDPOINTS.md) - Backend API docs
-- [Setup Guide](docs/SETUP.md) - Development setup
+- [Architecture template](docs/ARCHITECTURE_TEMPLATE.md)
+- [Dev runbook template](docs/DEV_RUNBOOK_TEMPLATE.md)
+- [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
+- [Blueprint](docs/BLUEPRINT.md) — Genesis framework architecture
 
 ---
 
-**Last Updated:** 2025-02-04
+**Last Updated:** 2026-05-31

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Genesis is the planning workflow that converts a prompt into the genome the runt
 
 The script copies everything needed for e2e (`npm test`, `node scripts/run-path.js` work immediately). Options: `--force` (allow non-empty target), `--no-verify` (skip post-copy `npm test`).
 
+**After instantiate — customize for your app:**
+
+1. Copy [docs/ARCHITECTURE_TEMPLATE.md](docs/ARCHITECTURE_TEMPLATE.md) → `docs/ARCHITECTURE.md`
+2. Copy [docs/DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` (fill in as you debug)
+3. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
+4. Add a **“This repo”** section to `.cursor/commands/workflow.md` with your stack-specific backend paths
+
 ---
 
 ## The process (simple)

--- a/docs/ARCHITECTURE_TEMPLATE.md
+++ b/docs/ARCHITECTURE_TEMPLATE.md
@@ -1,0 +1,41 @@
+# Architecture (template)
+
+Copy to **`docs/ARCHITECTURE.md`** during `/create_plan` or `/execute_plan`. Replace placeholders with your stack.
+
+## Overview
+
+_One paragraph: what the app does and main technologies._
+
+## Module layout
+
+```
+src/ or web/ api/ ...
+```
+
+## Backend entry points (required for API projects)
+
+Document **every** environment that serves HTTP:
+
+| Environment | Entry file | Base path | How to run | Deploy |
+|-------------|------------|-----------|------------|--------|
+| Local dev | _e.g. `api/src/server.ts`_ | _e.g. `/api`_ | _e.g. `npm run dev:api`_ | — |
+| Production | _e.g. `functions/src/index.ts`_ | _e.g. `/api`_ | — | _e.g. `firebase deploy --only functions`_ |
+
+**Rule:** Shared route handlers live in **one place** (e.g. `api/src/handlers/`). Both entry points import the same router — do not duplicate route definitions in separate files unless unavoidable.
+
+## Web → API
+
+| Build | `VITE_API_BASE_URL` / equivalent |
+|-------|----------------------------------|
+| Local | Full URL including base path, e.g. `http://localhost:3001/api` |
+| Production | Relative path matching hosting rewrite, e.g. `/api` |
+
+## Security
+
+- Auth: _how uid is derived (never from client body)_
+- Secrets: _server-only; Firestore rules deny client access to sensitive subcollections_
+
+## External services
+
+| Service | Usage |
+|---------|--------|

--- a/docs/DEV_RUNBOOK_TEMPLATE.md
+++ b/docs/DEV_RUNBOOK_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Dev Runbook (template)
+
+Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-specific commands and symptom/fix rows as you debug.
+
+## Start commands
+
+| Service | Command | URL / port |
+|---------|---------|------------|
+| Backend | _e.g. `npm run dev:api`_ | _e.g. `http://localhost:3001/api`_ |
+| Frontend | _e.g. `npm run dev:web`_ | _e.g. `http://localhost:5173`_ |
+| Database / emulators | _e.g. `npm run dev:emulators`_ | _ports_ |
+
+## Hard requirements
+
+| Rule | Why |
+|------|-----|
+| _e.g. Use localhost, not LAN IP for OAuth_ | _Firebase authorized domains_ |
+| _e.g. Run seed script after emulator start_ | _Empty catalog_ |
+| _e.g. Root `.env` loaded by API_ | _Missing credentials_ |
+
+## Symptom → fix
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| _API empty response / crash_ | Unhandled error in handler | Global error handler; check API logs |
+| _Auth redirect 401_ | Cross-origin auth on localhost | Popup in dev or auth proxy; see Firebase redirect best practices |
+| _404 on API in production_ | Path prefix / hosting rewrite mismatch | Document in `docs/ARCHITECTURE.md`; align router mount with hosting |
+
+Add a row here whenever debugging takes more than 30 minutes.
+
+## QA gate
+
+Before the next feature: run `/qa_checklist` → `/code_review` → `/postmortem`.

--- a/docs/PRODUCT_VS_GENOME_MISSION.md
+++ b/docs/PRODUCT_VS_GENOME_MISSION.md
@@ -1,0 +1,19 @@
+# Product mission vs `.genome/mission.md`
+
+Two different “missions” coexist in an instantiated project. Do not conflate them.
+
+| | **Product mission** | **Genome mission** (`.genome/mission.md`) |
+|---|---------------------|-------------------------------------------|
+| **Purpose** | What your app/product delivers for users | What the Genesis **framework/runtime** blueprint defines |
+| **Audience** | You, users, stakeholders | Organism loader, decomposition engine, Genesis meta-tests |
+| **Updates** | Capture, plan, closure docs (`docs/CLOSURE_*.md`) | Genome workflow; rarely changed after instantiate |
+| **Example** | “Track Amex benefits via Plaid” | “Provide validated blueprint for organism structure…” |
+
+## After `instantiate.sh`
+
+1. **Keep** `.genome/mission.md` as framework metadata unless you are extending Project Genesis itself.
+2. **Capture product intent** in `/capture_issue` → `.ai/context/last_capture.md` and your execution plan.
+3. **Optionally** add `docs/MISSION.md` or `README.md` for human-readable product goals.
+4. **Customize** `.cursor/commands/workflow.md` with stack-specific notes (backend paths, runbook link).
+
+Completing an **app MVP** does not mean the **genome organism runtime** is finished — they are separate concerns.


### PR DESCRIPTION
## Summary

Informed by building a greenfield app with `instantiate.sh` (Wallet Watcher). The copied workflow still referenced **Epiphoric** (`server.js` + `functions/index.js` duplication) and skipped enforced QA gates after MVP `/execute_plan`.

This PR makes Genesis **stack-agnostic** for instantiated product repos and adds templates for ops docs teams fill in during build.

## Changes

- **Workflow commands** (`workflow`, `create_plan`, `design_decisions`, `execute_plan`, `pre_implementation_checklist`, `code_review`, `explore`): replace hard-coded Firebase/Express file pairs with “document entry points in `docs/ARCHITECTURE.md` + shared handlers”
- **MVP quality gate**: require `/code_review` + `/qa_checklist` after milestone `/execute_plan` before next feature
- **Greenfield planning**: bootable milestone, first-run verification, production path check in `create_plan`
- **New templates**:
  - `docs/ARCHITECTURE_TEMPLATE.md`
  - `docs/DEV_RUNBOOK_TEMPLATE.md`
  - `docs/PRODUCT_VS_GENOME_MISSION.md` (clarifies `.genome/mission.md` vs product goals)
- **README**: post-instantiate customization checklist

## Test plan

- [x] `npm test` — 61/62 pass (pre-existing `instantiate` meta-test failure unchanged)
- [ ] Review workflow command diffs for clarity on fresh instantiate
- [ ] Optional: instantiate into temp dir and confirm templates + commands copy correctly

## Notes

Does not change organism runtime (`lib/`, `.genome/` decomposition). App-specific runbook content stays in instantiated repos, not upstream.


Made with [Cursor](https://cursor.com)