### PR TITLE
Production parity + GitHub Pages learnings from AI Tastemakers

### DIFF
--- a/.cursor/commands/design_decisions.md
+++ b/.cursor/commands/design_decisions.md
@@ -71,6 +71,26 @@ For auth, payments, email, or third-party APIs, document:
 
 Copy [DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` and add rows as you learn.
 
+### 10. External API identifiers (verify at implement time)
+
+For LLM, payment, or vendor APIs, document:
+
+| Integration | Env var | Identifier (model, API version, etc.) | Verify at ship |
+|-------------|---------|----------------------------------------|----------------|
+| _e.g. Anthropic_ | `ANTHROPIC_API_KEY` | _e.g. `claude-sonnet-4-6`_ | _Provider docs — IDs retire_ |
+
+Rules:
+- **Do not treat design-doc model names as stable forever.** Check provider docs when implementing and in `.env.example`.
+- Note rate limits and which token works in CI (e.g. `GITHUB_TOKEN` vs PAT for Search API).
+
+### 11. Cold-start / bootstrap behavior (ranking, ML, analytics)
+
+If v1 quality depends on accumulated history (snapshots, training data, A/B baseline):
+
+- Document bootstrap fallback behavior and when “real” mode activates
+- Set user expectations in explore/capture: _“Rankings improve after ~N days of daily runs”_
+- Avoid promising full product quality on day one unless technically accurate
+
 Rules:
 - Favor reversible decisions
 - Avoid overengineering

--- a/.cursor/commands/execute_plan.md
+++ b/.cursor/commands/execute_plan.md
@@ -55,6 +55,27 @@ Validation (at the end):
 - Verify format conversions work as documented (if applicable)
 - Ensure no constraints were violated
 
+## Local Dev Verification (required before handoff)
+
+- [ ] If feature reads persisted user/data store: **seed script or documented integration path** exists in `package.json` (do not document scripts that are not implemented)
+- [ ] `docs/DEV_RUNBOOK.md` updated with new scripts, ports, or recovery steps
+- [ ] Agent ran `npm test` and `npm run build` for affected workspaces (or stack-equivalent)
+- [ ] Agent stated exact commands for the user to see the happy path (e.g. seed → open page)
+- [ ] If editing shared workspace packages: noted whether consumers import `dist/` or `src/` — rebuild/restart as needed
+
+## Deployment Verification (required when feature ships via GHA, cron, or static hosting)
+
+Skip only if the feature has **no** automated deploy and **no** public URL.
+
+- [ ] Repo secrets documented in runbook (e.g. `ANTHROPIC_API_KEY`); never committed
+- [ ] Real git remote set (`gh repo create` / `git remote set-url`) — no `YOU/repo` placeholder
+- [ ] Manual workflow dispatch succeeds (or cron path documented)
+- [ ] Expected artifact exists on remote (commit, file, or deploy output)
+- [ ] **Public URL loads correctly** (hard refresh): styled UI if applicable, not raw HTML
+- [ ] **GitHub Pages project sites:** asset paths are **relative** (`assets/style.css`, `../assets/style.css`) — not root-absolute `/assets/…` (see [GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md))
+- [ ] Timezone consistency: commit messages and dated output folders use the same TZ
+- [ ] After GHA bot commits: local push may need `git pull --rebase origin main`
+
 If a step feels unsafe or unclear, stop and ask before proceeding.
 
 ---

--- a/.cursor/commands/postmortem.md
+++ b/.cursor/commands/postmortem.md
@@ -13,6 +13,9 @@ Then answer:
 2. What should change in prompts or docs
 3. How to prevent this next time
 
+**Also document:**
+- Which workflow phases were **skipped** (e.g. `/code_review`, `/qa_checklist`, `/security_scan`) and whether that is acceptable for this milestone
+
 Finally, propose updates to:
 - System instructions
 - Documentation

--- a/.cursor/commands/workflow.md
+++ b/.cursor/commands/workflow.md
@@ -172,6 +172,7 @@ For smaller changes or bug fixes:
 2. Copy [docs/DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` as you debug.
 3. Add a **“This repo”** subsection below with your backend paths and runbook link.
 4. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
+5. If shipping GitHub Pages: read [GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md).
 
 ---
 
@@ -185,6 +186,15 @@ For smaller changes or bug fixes:
 6. **Missing Format Conversions** - Document and implement all format conversions
 7. **Skipping Pre-Implementation Checklist** - Verify all requirements before coding
 8. **Forgetting to stage before commit** - Run `git add -A` before `git commit` when shipping changes
+9. **Documenting npm scripts that don't exist** - Runbook must not require scripts missing from `package.json`
+10. **Stale `last_plan.md`** - Plan issue ID must match current capture before `/execute_plan`
+11. **Monorepo shared package drift** - Rebuild shared workspace packages after editing `src/` if consumers import `dist/`
+12. **QA-driven silent scope** - New requests during QA need a mini capture or plan note, not ad-hoc patches
+13. **Local-only “done” for scheduled products** - MVP includes secrets, GHA dispatch, and verifying the public artifact
+14. **GitHub Pages root-absolute paths** - On `username.github.io/repo/`, use relative asset paths (`assets/style.css`), not `/assets/`
+15. **Placeholder git remote** - Replace `YOU/repo` with `gh repo create` before first push
+16. **Stale external API IDs** - Verify LLM/vendor model names at implement time; provider IDs retire
+17. **GHA bot vs local git** - Run `git pull --rebase` after Actions commits before pushing locally
 
 ---
 
@@ -192,9 +202,11 @@ For smaller changes or bug fixes:
 
 - [Architecture template](docs/ARCHITECTURE_TEMPLATE.md)
 - [Dev runbook template](docs/DEV_RUNBOOK_TEMPLATE.md)
+- [GitHub Pages checklist](docs/GITHUB_PAGES_CHECKLIST.md)
 - [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
+- [Instantiated app feedback log](docs/INSTANTIATED_APP_FEEDBACK.md)
 - [Blueprint](docs/BLUEPRINT.md) — Genesis framework architecture
 
 ---
 
-**Last Updated:** 2026-05-31
+**Last Updated:** 2026-06-07

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ The script copies everything needed for e2e (`npm test`, `node scripts/run-path.
 3. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
 4. Add a **“This repo”** section to `.cursor/commands/workflow.md` with your stack-specific backend paths
 
+**Post-instantiate — git and GitHub (recommended before first feature ship):**
+
+```bash
+cd /path/to/my-organism
+git init
+git add .
+git commit -m "chore: instantiate from project-genesis"
+gh repo create MY-USER/MY-REPO --public --source=. --remote=origin --push
+# Or: git remote add origin git@github.com:MY-USER/MY-REPO.git && git push -u origin main
+```
+
+- Never use placeholder remotes like `YOU/repo`
+- Add `.env` to `.gitignore`; copy `.env.example` → `.env` locally only
+- If using GitHub Actions or Pages: set secrets, run one manual workflow dispatch, verify public URL
+
+See [docs/GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md) for static site hosting.
+
 ---
 
 ## The process (simple)
@@ -222,6 +239,8 @@ All of this is synchronous. No daemon, no background process. One invocation run
 - **[lib/README.md](lib/README.md)** — Runtime API: `loadGenome`, `decompose`, signaling, `runPath`, `runPathWithRepair`, guardrails.
 - **[docs/VALIDATION_STORY_12.md](docs/VALIDATION_STORY_12.md)** — Validation checklist (acceptance criteria and guardrails).
 - **[docs/GITHUB_SETTINGS.md](docs/GITHUB_SETTINGS.md)** — Repository governance.
+- **[docs/GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md)** — Static site hosting on `username.github.io/repo/`.
+- **[docs/INSTANTIATED_APP_FEEDBACK.md](docs/INSTANTIATED_APP_FEEDBACK.md)** — Postmortem learnings from instantiated apps.
 - **.cursor/commands/** — Workflow automation (capture_issue, explore, design_decisions, create_plan, execute_plan, code_review, qa_checklist, postmortem).
 
 ---

--- a/docs/DEV_RUNBOOK_TEMPLATE.md
+++ b/docs/DEV_RUNBOOK_TEMPLATE.md
@@ -2,6 +2,18 @@
 
 Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-specific commands and symptom/fix rows as you debug.
 
+> **Script integrity rule:** Do not document an `npm run …` command until it exists in root `package.json`. If deferred, mark as `(planned)` — not as a hard requirement.
+
+## Terminology (customize for your stack)
+
+| Term | Example meaning |
+|------|-----------------|
+| **Local dev** | localhost frontend + API + emulators |
+| **Vendor sandbox** | Third-party test API (not production) |
+| **Seed / fixture data** | Scripts that populate local DB for demos |
+| **Scheduled job** | Cron, GitHub Actions, or worker that runs unattended |
+| **Staging** | Hosted pre-production environment (if you have one) |
+
 ## Start commands
 
 | Service | Command | URL / port |
@@ -9,6 +21,7 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | Backend | _e.g. `npm run dev:api`_ | _e.g. `http://localhost:3001/api`_ |
 | Frontend | _e.g. `npm run dev:web`_ | _e.g. `http://localhost:5173`_ |
 | Database / emulators | _e.g. `npm run dev:emulators`_ | _ports_ |
+| Scheduled / CLI job | _e.g. `npm run digest`_ | _writes to `briefings/`_ |
 
 ## Hard requirements
 
@@ -17,6 +30,25 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | _e.g. Use localhost, not LAN IP for OAuth_ | _Firebase authorized domains_ |
 | _e.g. Run seed script after emulator start_ | _Empty catalog_ |
 | _e.g. Root `.env` loaded by API_ | _Missing credentials_ |
+| Never commit `.env` | Secrets |
+
+## Scheduled job / GitHub Actions (if applicable)
+
+| Step | Command / location |
+|------|-------------------|
+| Workflow file | _e.g. `.github/workflows/digest.yml`_ |
+| Required secrets | _e.g. `ANTHROPIC_API_KEY`_ |
+| Manual test | _e.g. `gh workflow run "Daily Digest"`_ |
+| Expected artifact | _e.g. commit to `briefings/`, Pages deploy_ |
+| Public URL | _e.g. `https://USER.github.io/REPO/`_ |
+
+**Deployment verification (MVP):**
+
+1. Set secrets on GitHub repo
+2. Run workflow manually once
+3. Confirm artifact on `main`
+4. Load public URL; verify CSS/UI (not unstyled HTML)
+5. See [GITHUB_PAGES_CHECKLIST.md](GITHUB_PAGES_CHECKLIST.md) for static sites
 
 ## Symptom → fix
 
@@ -25,6 +57,9 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | _API empty response / crash_ | Unhandled error in handler | Global error handler; check API logs |
 | _Auth redirect 401_ | Cross-origin auth on localhost | Popup in dev or auth proxy; see Firebase redirect best practices |
 | _404 on API in production_ | Path prefix / hosting rewrite mismatch | Document in `docs/ARCHITECTURE.md`; align router mount with hosting |
+| _GitHub Pages unstyled_ | Root-absolute `/assets/…` on project site | Use relative paths; see GITHUB_PAGES_CHECKLIST |
+| _API 404 model not found_ | Deprecated provider model ID | Verify current ID in provider docs; update `.env` |
+| _git push rejected (non-fast-forward)_ | GHA bot pushed commits | `git pull --rebase origin main` then push |
 
 Add a row here whenever debugging takes more than 30 minutes.
 

--- a/docs/GITHUB_PAGES_CHECKLIST.md
+++ b/docs/GITHUB_PAGES_CHECKLIST.md
@@ -1,0 +1,68 @@
+# GitHub Pages checklist (template)
+
+Use when shipping a static site from an instantiated app (e.g. daily digest, docs site, landing page).
+
+Copy relevant rows into `docs/DEV_RUNBOOK.md` when you deploy.
+
+---
+
+## URL shape
+
+| Hosting | Example URL | Asset path rule |
+|---------|-------------|-----------------|
+| **Project site** | `https://USER.github.io/REPO/` | **Relative** paths only |
+| User/org site | `https://USER.github.io/` | Root-absolute `/assets/…` OK |
+
+Most instantiated apps use **project sites**. Root-absolute `/assets/style.css` resolves to `USER.github.io/assets/…` → **404** → unstyled HTML.
+
+---
+
+## Build checklist
+
+- [ ] CSS/JS built in CI (`npm run build:pages` or equivalent) — do not rely on committed generated CSS unless intentional
+- [ ] HTML uses relative paths:
+  - From site root: `assets/style.css`, `briefings/2026-06-06.html`
+  - From subfolder: `../assets/style.css`, `../index.html`
+- [ ] Optional: `<base href="/REPO/">` only if **all** links are relative (no leading `/`)
+- [ ] `site/.nojekyll` present if using folders starting with `_` or dotfiles
+- [ ] Pages workflow verifies artifact exists (e.g. `test -s site/assets/style.css`)
+
+---
+
+## Deploy checklist
+
+- [ ] Repo **Settings → Pages → Source**: GitHub Actions (or `/docs` on `main`)
+- [ ] Workflow has `permissions: pages: write` and `id-token: write` for Actions deploy
+- [ ] Push to `main` triggers deploy (or manual `workflow_dispatch`)
+- [ ] Hard-refresh production URL — confirm styled layout
+- [ ] Brief/deep links work from homepage (not 404)
+
+---
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Unstyled HTML, default browser fonts | CSS 404 at domain root | Relative asset paths |
+| CSS works locally, broken on GitHub | `npx serve site` uses `/` root; GitHub uses `/REPO/` | Same relative-path fix |
+| Deploy succeeds, old content | CDN cache | Hard refresh; wait ~1 min |
+| Pages 404 | Wrong branch/folder in Settings | Align with workflow artifact path |
+
+---
+
+## Tailwind / build-time CSS
+
+GitHub Pages serves static files only. Compile Tailwind (or PostCSS) **in CI**:
+
+```json
+"build:pages": "tsx scripts/build-pages.ts && tailwindcss -i site/assets/input.css -o site/assets/style.css --minify"
+```
+
+Track `input.css` in git; gitignore generated `style.css` if CI always rebuilds.
+
+---
+
+## Related
+
+- [GITHUB_SETTINGS.md](GITHUB_SETTINGS.md) — branch protection, issues
+- [DEV_RUNBOOK_TEMPLATE.md](DEV_RUNBOOK_TEMPLATE.md) — scheduled jobs section

--- a/docs/INSTANTIATED_APP_FEEDBACK.md
+++ b/docs/INSTANTIATED_APP_FEEDBACK.md
@@ -1,0 +1,60 @@
+# Instantiated App Feedback Log
+
+Changelog of workflow improvements derived from real app development (postmortems). Use when updating Genesis templates and Cursor commands.
+
+---
+
+## 2026-05-31 — Wallet Watcher (Transactions, EPH-20260531-H3M8)
+
+**Source:** Greenfield feature after MVP; full Genesis workflow (capture → explore → design → plan → execute → code review → QA → postmortem).
+
+### Friction observed
+
+| Area | Issue |
+|------|--------|
+| Local dev parity | Runbook referenced seed script before it existed in `package.json` |
+| Execute handoff | Feature “done” but UI empty without user-driven seed/debug |
+| Monorepo | API imported shared package from `dist/`; edits silent until rebuild |
+| Emulator lifecycle | Port conflicts, duplicate emulator instances blocked QA |
+| Planning order | `/design_decisions` before `/create_plan`; stale plan file passed gate |
+| Multi-source data | Seed + vendor API data indistinguishable until late QA |
+| QA scope | Relink, source column, subscription fixes added ad-hoc during validation |
+
+### Root cause (process)
+
+Local dev parity was documented aspirationally but not treated as part of “done.” Demoability should be a deliverable, not a QA surprise.
+
+---
+
+## 2026-06-07 — AI Tastemakers (Daily Digest, EPH-20260606-DIG1)
+
+**Source:** Greenfield instantiate → deploy (capture → explore → design → plan → execute → GitHub Actions + GitHub Pages).
+
+### Friction observed
+
+| Area | Issue |
+|------|--------|
+| External APIs | Deprecated Anthropic model ID in `.env.example` → 404 on all narrations |
+| Git | Placeholder remote `YOU/repo`; push failed until `gh repo create` |
+| GHA vs local git | Bot commit caused non-fast-forward push; needed `git pull --rebase` |
+| GitHub Pages | Root-absolute `/assets/style.css` → unstyled site on project URL |
+| MVP definition | Local CLI success treated as “done”; production URL/CSS not verified |
+| Ranking UX | Bootstrap mode surfaced mega-repos; cold-start not documented upfront |
+
+### Root cause (process)
+
+**Production parity** missing from MVP definition. Scheduled/automated products need deployment verification (secrets, GHA dispatch, public artifact) — not just local run + unit tests.
+
+### Changes incorporated into Genesis (PR `improve/tastemakers-postmortem-dig1`)
+
+- `/execute_plan` — Deployment verification gate
+- `/design_decisions` — External API identifiers; cold-start / bootstrap caveat
+- `/postmortem` — List skipped workflow phases
+- `/workflow` — Common mistakes (Pages paths, git remote, API IDs, GHA rebase, production parity)
+- `DEV_RUNBOOK_TEMPLATE` — Scheduled job section; script integrity rule
+- `docs/GITHUB_PAGES_CHECKLIST.md` — New template
+- `README.md` — Post-instantiate git + GitHub block
+
+---
+
+**How to add entries:** After `/postmortem` in an instantiated app, open a PR to [project-genesis](https://github.com/Leftyshields/project-genesis) or append here via PR from your app repo.


### PR DESCRIPTION
## Summary

Upstream workflow improvements from [AI Tastemakers](https://github.com/Leftyshields/ai-tastemakers) postmortem (EPH-20260606-DIG1). Addresses **production parity** — the gap between “local CLI works” and “scheduled job + public URL works.”

- **`/execute_plan`** — Deployment verification gate (secrets, GHA dispatch, Pages CSS, git rebase)
- **`/design_decisions`** — External API identifiers (verify at implement time); cold-start/bootstrap caveat
- **`/postmortem`** — Document skipped workflow phases
- **`/workflow`** — Common mistakes #13–17 (Pages paths, git remote, API IDs, GHA rebase)
- **`DEV_RUNBOOK_TEMPLATE`** — Scheduled job / GitHub Actions section; script integrity rule
- **`GITHUB_PAGES_CHECKLIST.md`** — New template for `username.github.io/repo/` hosting
- **`INSTANTIATED_APP_FEEDBACK.md`** — Feedback log (Wallet Watcher + AI Tastemakers entries)
- **`README`** — Post-instantiate git + GitHub setup block

## Test plan

- [ ] Review `/execute_plan` deployment checklist against a GHA + Pages app
- [ ] Confirm `GITHUB_PAGES_CHECKLIST.md` relative-path guidance matches project-site behavior
- [ ] Re-instantiate a test app and verify new README git block is clear


Made with [Cursor](https://cursor.com)