### PR TITLE
Workflow course + COPY postmortem lessons (EPH-20260607)

### DIFF
--- a/.cursor/commands/design_decisions.md
+++ b/.cursor/commands/design_decisions.md
@@ -71,6 +71,26 @@ For auth, payments, email, or third-party APIs, document:
 
 Copy [DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` and add rows as you learn.
 
+### 10. External API identifiers (verify at implement time)
+
+For LLM, payment, or vendor APIs, document:
+
+| Integration | Env var | Identifier (model, API version, etc.) | Verify at ship |
+|-------------|---------|----------------------------------------|----------------|
+| _e.g. Anthropic_ | `ANTHROPIC_API_KEY` | _e.g. `claude-sonnet-4-6`_ | _Provider docs — IDs retire_ |
+
+Rules:
+- **Do not treat design-doc model names as stable forever.** Check provider docs when implementing and in `.env.example`.
+- Note rate limits and which token works in CI (e.g. `GITHUB_TOKEN` vs PAT for Search API).
+
+### 11. Cold-start / bootstrap behavior (ranking, ML, analytics)
+
+If v1 quality depends on accumulated history (snapshots, training data, A/B baseline):
+
+- Document bootstrap fallback behavior and when “real” mode activates
+- Set user expectations in explore/capture: _“Rankings improve after ~N days of daily runs”_
+- Avoid promising full product quality on day one unless technically accurate
+
 Rules:
 - Favor reversible decisions
 - Avoid overengineering

--- a/.cursor/commands/execute_plan.md
+++ b/.cursor/commands/execute_plan.md
@@ -75,6 +75,8 @@ Skip only if the feature has **no** automated deploy and **no** public URL.
 - [ ] **GitHub Pages project sites:** asset paths are **relative** (`assets/style.css`, `../assets/style.css`) — not root-absolute `/assets/…` (see [GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md))
 - [ ] Timezone consistency: commit messages and dated output folders use the same TZ
 - [ ] After GHA bot commits: local push may need `git pull --rebase origin main`
+- [ ] After bot commits dated artifacts (`briefings/`, reports): deploy workflow ran or was dispatched manually
+- [ ] **Same-day pipeline re-run:** If verifying prompt/output-format changes, prefer `npm test` + GHA dispatch — local re-run when today's output folder exists can reshuffle rankings or drift metrics (see [WORKFLOW_COURSE.md](docs/WORKFLOW_COURSE.md))
 
 If a step feels unsafe or unclear, stop and ask before proceeding.
 

--- a/.cursor/commands/execute_plan.md
+++ b/.cursor/commands/execute_plan.md
@@ -55,6 +55,27 @@ Validation (at the end):
 - Verify format conversions work as documented (if applicable)
 - Ensure no constraints were violated
 
+## Local Dev Verification (required before handoff)
+
+- [ ] If feature reads persisted user/data store: **seed script or documented integration path** exists in `package.json` (do not document scripts that are not implemented)
+- [ ] `docs/DEV_RUNBOOK.md` updated with new scripts, ports, or recovery steps
+- [ ] Agent ran `npm test` and `npm run build` for affected workspaces (or stack-equivalent)
+- [ ] Agent stated exact commands for the user to see the happy path (e.g. seed → open page)
+- [ ] If editing shared workspace packages: noted whether consumers import `dist/` or `src/` — rebuild/restart as needed
+
+## Deployment Verification (required when feature ships via GHA, cron, or static hosting)
+
+Skip only if the feature has **no** automated deploy and **no** public URL.
+
+- [ ] Repo secrets documented in runbook (e.g. `ANTHROPIC_API_KEY`); never committed
+- [ ] Real git remote set (`gh repo create` / `git remote set-url`) — no `YOU/repo` placeholder
+- [ ] Manual workflow dispatch succeeds (or cron path documented)
+- [ ] Expected artifact exists on remote (commit, file, or deploy output)
+- [ ] **Public URL loads correctly** (hard refresh): styled UI if applicable, not raw HTML
+- [ ] **GitHub Pages project sites:** asset paths are **relative** (`assets/style.css`, `../assets/style.css`) — not root-absolute `/assets/…` (see [GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md))
+- [ ] Timezone consistency: commit messages and dated output folders use the same TZ
+- [ ] After GHA bot commits: local push may need `git pull --rebase origin main`
+
 If a step feels unsafe or unclear, stop and ask before proceeding.
 
 ---

--- a/.cursor/commands/postmortem.md
+++ b/.cursor/commands/postmortem.md
@@ -21,6 +21,12 @@ Finally, propose updates to:
 - Documentation
 - Workflow rules
 
+**Required outputs:**
+1. `.ai/context/postmortem_<ISSUE_ID>.md` — friction analysis (this session)
+2. `docs/CLOSURE_<ISSUE_ID>.md` — what shipped, deferred, ship commands
+3. Update `.cursor/commands/workflow.md` or related commands if lessons apply
+4. Optional upstream: contribute findings to [Project Genesis](https://github.com/Leftyshields/project-genesis) via PR or `docs/INSTANTIATED_APP_FEEDBACK.md` in your app repo
+
 ---
 
 **Workflow Position:** Run this after feature deployment to reflect on the process and improve future workflows.

--- a/.cursor/commands/postmortem.md
+++ b/.cursor/commands/postmortem.md
@@ -13,6 +13,9 @@ Then answer:
 2. What should change in prompts or docs
 3. How to prevent this next time
 
+**Also document:**
+- Which workflow phases were **skipped** (e.g. `/code_review`, `/qa_checklist`, `/security_scan`) and whether that is acceptable for this milestone
+
 Finally, propose updates to:
 - System instructions
 - Documentation

--- a/.cursor/commands/pre_implementation_checklist.md
+++ b/.cursor/commands/pre_implementation_checklist.md
@@ -125,7 +125,9 @@ If using React state updates:
 - If any item cannot be checked off, stop and complete it before proceeding
 - Missing specifications at this stage will cause rework during implementation
 - It's better to spend time planning than debugging later
-- **If no execution plan file exists:** You may proceed using the implementation outline in design_decisions (e.g. User Flow, Integration Points, Resource/New files) as the execution guide; run `/create_plan` optionally for a formal step list.
+- **`last_plan.md` issue ID must match `last_capture.md`** before `/execute_plan`
+- **If no execution plan file exists:** For features, run `/create_plan` first; design_decisions alone is only for small fixes
+- **Scheduled/dated output products:** Document verification path in design decisions — test-only vs GHA dispatch vs local pipeline re-run (see [WORKFLOW_COURSE.md](docs/WORKFLOW_COURSE.md))
 
 ---
 

--- a/.cursor/commands/workflow.md
+++ b/.cursor/commands/workflow.md
@@ -29,14 +29,18 @@ See also: [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
    - Include field mappings (if data transformations)
    - Include format conversions (if needed)
    - Include local dev parity checks (if API endpoints)
+   - **Issue ID in `last_plan.md` must match `last_capture.md`**
    
-   **Next:** Run `/design_decisions` to document design choices
+   **Next:** Run `/design_decisions` (if not done) or `/pre_implementation_checklist`
 
 4. **Document Design Decisions** (`/design_decisions`)
    - Answer all open questions from planning
    - Define field update strategies
    - Specify rendering approaches (if formatted content)
    - Document integration points
+   - **For multi-source data:** document provenance (API vs seed vs manual) and reconnect cleanup
+   
+   **Note:** May run before or after `/create_plan`, but **both** must exist before `/execute_plan`.
    
    **Next:** Run `/pre_implementation_checklist` to verify readiness
 
@@ -112,6 +116,7 @@ See also: [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
 12. **Postmortem** (`/postmortem`) — *standard*
     - Analyze friction points, rework, missing docs
     - Document lessons learned; propose workflow/doc updates
+    - Create `docs/CLOSURE_EPH-*.md` for the issue
     
     **Next:** Run `/project_wrap_up` (optional) or start next feature
 
@@ -195,11 +200,15 @@ For smaller changes or bug fixes:
 15. **Placeholder git remote** - Replace `YOU/repo` with `gh repo create` before first push
 16. **Stale external API IDs** - Verify LLM/vendor model names at implement time; provider IDs retire
 17. **GHA bot vs local git** - Run `git pull --rebase` after Actions commits before pushing locally
+18. **Same-day pipeline re-run** - Re-running a dated job when today's output folder already exists can reshuffle rankings (soft-dedup) and drift metrics (live API refresh). Prefer tests + GHA dispatch for prompt/format verification
+19. **Stale plan on follow-on issues** - Run `/create_plan` for the new issue ID; do not reuse a closed issue's `execution_plan.md`
+20. **GHA artifact without deploy** - Bot commits to `briefings/` or `dist/` may not trigger Pages; verify deploy workflow or dispatch manually
 
 ---
 
 ## 📚 Related Documentation (templates — copy into your app repo)
 
+- [Workflow course](docs/WORKFLOW_COURSE.md) — case studies and anti-patterns
 - [Architecture template](docs/ARCHITECTURE_TEMPLATE.md)
 - [Dev runbook template](docs/DEV_RUNBOOK_TEMPLATE.md)
 - [GitHub Pages checklist](docs/GITHUB_PAGES_CHECKLIST.md)

--- a/.cursor/commands/workflow.md
+++ b/.cursor/commands/workflow.md
@@ -172,6 +172,7 @@ For smaller changes or bug fixes:
 2. Copy [docs/DEV_RUNBOOK_TEMPLATE.md](docs/DEV_RUNBOOK_TEMPLATE.md) → `docs/DEV_RUNBOOK.md` as you debug.
 3. Add a **“This repo”** subsection below with your backend paths and runbook link.
 4. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md).
+5. If shipping GitHub Pages: read [GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md).
 
 ---
 
@@ -185,6 +186,15 @@ For smaller changes or bug fixes:
 6. **Missing Format Conversions** - Document and implement all format conversions
 7. **Skipping Pre-Implementation Checklist** - Verify all requirements before coding
 8. **Forgetting to stage before commit** - Run `git add -A` before `git commit` when shipping changes
+9. **Documenting npm scripts that don't exist** - Runbook must not require scripts missing from `package.json`
+10. **Stale `last_plan.md`** - Plan issue ID must match current capture before `/execute_plan`
+11. **Monorepo shared package drift** - Rebuild shared workspace packages after editing `src/` if consumers import `dist/`
+12. **QA-driven silent scope** - New requests during QA need a mini capture or plan note, not ad-hoc patches
+13. **Local-only “done” for scheduled products** - MVP includes secrets, GHA dispatch, and verifying the public artifact
+14. **GitHub Pages root-absolute paths** - On `username.github.io/repo/`, use relative asset paths (`assets/style.css`), not `/assets/`
+15. **Placeholder git remote** - Replace `YOU/repo` with `gh repo create` before first push
+16. **Stale external API IDs** - Verify LLM/vendor model names at implement time; provider IDs retire
+17. **GHA bot vs local git** - Run `git pull --rebase` after Actions commits before pushing locally
 
 ---
 
@@ -192,9 +202,11 @@ For smaller changes or bug fixes:
 
 - [Architecture template](docs/ARCHITECTURE_TEMPLATE.md)
 - [Dev runbook template](docs/DEV_RUNBOOK_TEMPLATE.md)
+- [GitHub Pages checklist](docs/GITHUB_PAGES_CHECKLIST.md)
 - [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
+- [Instantiated app feedback log](docs/INSTANTIATED_APP_FEEDBACK.md)
 - [Blueprint](docs/BLUEPRINT.md) — Genesis framework architecture
 
 ---
 
-**Last Updated:** 2026-05-31
+**Last Updated:** 2026-06-07

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Start with intent. End with a governed build.
 
 Genesis is the planning workflow that converts a prompt into the genome the runtime executes.
 
-**Start the workflow** — Run the Cursor command **`/capture_issue`** with your idea (goal or problem). Cursor guides you: explore → create plan → design decisions → pre-implementation checklist → execute plan. When the genome is ready, Cursor asks if you're done; when you confirm, the build runs and you get run-the-app instructions. Full workflow: [.cursor/commands/workflow.md](.cursor/commands/workflow.md).
+**Start the workflow** — Run the Cursor command **`/capture_issue`** with your idea (goal or problem). Cursor guides you: explore → create plan → design decisions → pre-implementation checklist → execute plan. When the genome is ready, Cursor asks if you're done; when you confirm, the build runs and you get run-the-app instructions. Full workflow: [.cursor/commands/workflow.md](.cursor/commands/workflow.md). **Workflow course** (case studies, anti-patterns): [docs/WORKFLOW_COURSE.md](docs/WORKFLOW_COURSE.md).
 
 1. **Capture** — `/capture_issue` with your prompt.
 2. **Explore, design, plan** — Work through the workflow; author or generate the genome in `.genome/`.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ The script copies everything needed for e2e (`npm test`, `node scripts/run-path.
 3. Read [Product vs genome mission](docs/PRODUCT_VS_GENOME_MISSION.md)
 4. Add a **“This repo”** section to `.cursor/commands/workflow.md` with your stack-specific backend paths
 
+**Post-instantiate — git and GitHub (recommended before first feature ship):**
+
+```bash
+cd /path/to/my-organism
+git init
+git add .
+git commit -m "chore: instantiate from project-genesis"
+gh repo create MY-USER/MY-REPO --public --source=. --remote=origin --push
+# Or: git remote add origin git@github.com:MY-USER/MY-REPO.git && git push -u origin main
+```
+
+- Never use placeholder remotes like `YOU/repo`
+- Add `.env` to `.gitignore`; copy `.env.example` → `.env` locally only
+- If using GitHub Actions or Pages: set secrets, run one manual workflow dispatch, verify public URL
+
+See [docs/GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md) for static site hosting.
+
 ---
 
 ## The process (simple)
@@ -222,6 +239,8 @@ All of this is synchronous. No daemon, no background process. One invocation run
 - **[lib/README.md](lib/README.md)** — Runtime API: `loadGenome`, `decompose`, signaling, `runPath`, `runPathWithRepair`, guardrails.
 - **[docs/VALIDATION_STORY_12.md](docs/VALIDATION_STORY_12.md)** — Validation checklist (acceptance criteria and guardrails).
 - **[docs/GITHUB_SETTINGS.md](docs/GITHUB_SETTINGS.md)** — Repository governance.
+- **[docs/GITHUB_PAGES_CHECKLIST.md](docs/GITHUB_PAGES_CHECKLIST.md)** — Static site hosting on `username.github.io/repo/`.
+- **[docs/INSTANTIATED_APP_FEEDBACK.md](docs/INSTANTIATED_APP_FEEDBACK.md)** — Postmortem learnings from instantiated apps.
 - **.cursor/commands/** — Workflow automation (capture_issue, explore, design_decisions, create_plan, execute_plan, code_review, qa_checklist, postmortem).
 
 ---

--- a/docs/DEV_RUNBOOK_TEMPLATE.md
+++ b/docs/DEV_RUNBOOK_TEMPLATE.md
@@ -48,7 +48,12 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 2. Run workflow manually once
 3. Confirm artifact on `main`
 4. Load public URL; verify CSS/UI (not unstyled HTML)
-5. See [GITHUB_PAGES_CHECKLIST.md](GITHUB_PAGES_CHECKLIST.md) for static sites
+5. After bot commits artifacts: verify deploy workflow ran (or dispatch manually)
+6. See [GITHUB_PAGES_CHECKLIST.md](GITHUB_PAGES_CHECKLIST.md) for static sites
+
+**Same-day re-run warning (dated output folders):**
+
+Re-running a scheduled job when `briefings/YYYY-MM-DD/` (or equivalent) already exists can change rankings (soft-dedup) or metrics (live API refresh). For prompt/format-only changes, prefer unit tests + GHA dispatch over local same-day re-run. See [WORKFLOW_COURSE.md](WORKFLOW_COURSE.md).
 
 ## Symptom → fix
 
@@ -60,6 +65,9 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | _GitHub Pages unstyled_ | Root-absolute `/assets/…` on project site | Use relative paths; see GITHUB_PAGES_CHECKLIST |
 | _API 404 model not found_ | Deprecated provider model ID | Verify current ID in provider docs; update `.env` |
 | _git push rejected (non-fast-forward)_ | GHA bot pushed commits | `git pull --rebase origin main` then push |
+| _Same-day job reshuffled output_ | Soft-dedup penalized today's existing folder | Exclude current date from dedup or use GHA as source of truth |
+| _Output metrics ≠ snapshot_ | Later stage re-fetched live API values | Document provenance; preserve snapshot fields on merge |
+| _Public site stale after bot commit_ | Deploy workflow did not run | `gh workflow run` deploy workflow; hard-refresh URL |
 
 Add a row here whenever debugging takes more than 30 minutes.
 

--- a/docs/DEV_RUNBOOK_TEMPLATE.md
+++ b/docs/DEV_RUNBOOK_TEMPLATE.md
@@ -2,6 +2,18 @@
 
 Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-specific commands and symptom/fix rows as you debug.
 
+> **Script integrity rule:** Do not document an `npm run …` command until it exists in root `package.json`. If deferred, mark as `(planned)` — not as a hard requirement.
+
+## Terminology (customize for your stack)
+
+| Term | Example meaning |
+|------|-----------------|
+| **Local dev** | localhost frontend + API + emulators |
+| **Vendor sandbox** | Third-party test API (not production) |
+| **Seed / fixture data** | Scripts that populate local DB for demos |
+| **Scheduled job** | Cron, GitHub Actions, or worker that runs unattended |
+| **Staging** | Hosted pre-production environment (if you have one) |
+
 ## Start commands
 
 | Service | Command | URL / port |
@@ -9,6 +21,7 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | Backend | _e.g. `npm run dev:api`_ | _e.g. `http://localhost:3001/api`_ |
 | Frontend | _e.g. `npm run dev:web`_ | _e.g. `http://localhost:5173`_ |
 | Database / emulators | _e.g. `npm run dev:emulators`_ | _ports_ |
+| Scheduled / CLI job | _e.g. `npm run digest`_ | _writes to `briefings/`_ |
 
 ## Hard requirements
 
@@ -17,6 +30,25 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | _e.g. Use localhost, not LAN IP for OAuth_ | _Firebase authorized domains_ |
 | _e.g. Run seed script after emulator start_ | _Empty catalog_ |
 | _e.g. Root `.env` loaded by API_ | _Missing credentials_ |
+| Never commit `.env` | Secrets |
+
+## Scheduled job / GitHub Actions (if applicable)
+
+| Step | Command / location |
+|------|-------------------|
+| Workflow file | _e.g. `.github/workflows/digest.yml`_ |
+| Required secrets | _e.g. `ANTHROPIC_API_KEY`_ |
+| Manual test | _e.g. `gh workflow run "Daily Digest"`_ |
+| Expected artifact | _e.g. commit to `briefings/`, Pages deploy_ |
+| Public URL | _e.g. `https://USER.github.io/REPO/`_ |
+
+**Deployment verification (MVP):**
+
+1. Set secrets on GitHub repo
+2. Run workflow manually once
+3. Confirm artifact on `main`
+4. Load public URL; verify CSS/UI (not unstyled HTML)
+5. See [GITHUB_PAGES_CHECKLIST.md](GITHUB_PAGES_CHECKLIST.md) for static sites
 
 ## Symptom → fix
 
@@ -25,6 +57,9 @@ Copy to **`docs/DEV_RUNBOOK.md`** in your instantiated project. Fill in stack-sp
 | _API empty response / crash_ | Unhandled error in handler | Global error handler; check API logs |
 | _Auth redirect 401_ | Cross-origin auth on localhost | Popup in dev or auth proxy; see Firebase redirect best practices |
 | _404 on API in production_ | Path prefix / hosting rewrite mismatch | Document in `docs/ARCHITECTURE.md`; align router mount with hosting |
+| _GitHub Pages unstyled_ | Root-absolute `/assets/…` on project site | Use relative paths; see GITHUB_PAGES_CHECKLIST |
+| _API 404 model not found_ | Deprecated provider model ID | Verify current ID in provider docs; update `.env` |
+| _git push rejected (non-fast-forward)_ | GHA bot pushed commits | `git pull --rebase origin main` then push |
 
 Add a row here whenever debugging takes more than 30 minutes.
 

--- a/docs/GITHUB_PAGES_CHECKLIST.md
+++ b/docs/GITHUB_PAGES_CHECKLIST.md
@@ -1,0 +1,68 @@
+# GitHub Pages checklist (template)
+
+Use when shipping a static site from an instantiated app (e.g. daily digest, docs site, landing page).
+
+Copy relevant rows into `docs/DEV_RUNBOOK.md` when you deploy.
+
+---
+
+## URL shape
+
+| Hosting | Example URL | Asset path rule |
+|---------|-------------|-----------------|
+| **Project site** | `https://USER.github.io/REPO/` | **Relative** paths only |
+| User/org site | `https://USER.github.io/` | Root-absolute `/assets/…` OK |
+
+Most instantiated apps use **project sites**. Root-absolute `/assets/style.css` resolves to `USER.github.io/assets/…` → **404** → unstyled HTML.
+
+---
+
+## Build checklist
+
+- [ ] CSS/JS built in CI (`npm run build:pages` or equivalent) — do not rely on committed generated CSS unless intentional
+- [ ] HTML uses relative paths:
+  - From site root: `assets/style.css`, `briefings/2026-06-06.html`
+  - From subfolder: `../assets/style.css`, `../index.html`
+- [ ] Optional: `<base href="/REPO/">` only if **all** links are relative (no leading `/`)
+- [ ] `site/.nojekyll` present if using folders starting with `_` or dotfiles
+- [ ] Pages workflow verifies artifact exists (e.g. `test -s site/assets/style.css`)
+
+---
+
+## Deploy checklist
+
+- [ ] Repo **Settings → Pages → Source**: GitHub Actions (or `/docs` on `main`)
+- [ ] Workflow has `permissions: pages: write` and `id-token: write` for Actions deploy
+- [ ] Push to `main` triggers deploy (or manual `workflow_dispatch`)
+- [ ] Hard-refresh production URL — confirm styled layout
+- [ ] Brief/deep links work from homepage (not 404)
+
+---
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Unstyled HTML, default browser fonts | CSS 404 at domain root | Relative asset paths |
+| CSS works locally, broken on GitHub | `npx serve site` uses `/` root; GitHub uses `/REPO/` | Same relative-path fix |
+| Deploy succeeds, old content | CDN cache | Hard refresh; wait ~1 min |
+| Pages 404 | Wrong branch/folder in Settings | Align with workflow artifact path |
+
+---
+
+## Tailwind / build-time CSS
+
+GitHub Pages serves static files only. Compile Tailwind (or PostCSS) **in CI**:
+
+```json
+"build:pages": "tsx scripts/build-pages.ts && tailwindcss -i site/assets/input.css -o site/assets/style.css --minify"
+```
+
+Track `input.css` in git; gitignore generated `style.css` if CI always rebuilds.
+
+---
+
+## Related
+
+- [GITHUB_SETTINGS.md](GITHUB_SETTINGS.md) — branch protection, issues
+- [DEV_RUNBOOK_TEMPLATE.md](DEV_RUNBOOK_TEMPLATE.md) — scheduled jobs section

--- a/docs/INSTANTIATED_APP_FEEDBACK.md
+++ b/docs/INSTANTIATED_APP_FEEDBACK.md
@@ -57,4 +57,31 @@ Local dev parity was documented aspirationally but not treated as part of “don
 
 ---
 
+## 2026-06-07 — AI Tastemakers (Copy + Brief Format, EPH-20260607-COPY)
+
+**Source:** Follow-on feature; design_decisions before create_plan; local same-day digest used for verification.
+
+### Friction observed
+
+| Area | Issue |
+|------|--------|
+| Planning order | Checklist blocked on stale DIG1 plan; `/create_plan` run late |
+| Verification | Same-day `npm run digest` reshuffled rankings (soft-dedup) |
+| Data provenance | Enrich overwrote snapshot star counts in digest output |
+| Deploy chain | GHA digest commit did not auto-trigger Pages deploy |
+| Scope | “Copy only” expanded to two pipeline stability fixes |
+
+### Root cause (process)
+
+**Scheduled pipeline re-runs are not idempotent** for date-stamped output. Verification strategy for prompt/format changes was undocumented.
+
+### Changes incorporated into Genesis (PR `improve/copy-postmortem-eph20260607`)
+
+- `docs/WORKFLOW_COURSE.md` — follow-on case study + idempotency section
+- `/workflow` — common mistakes 18–20; flexible design/plan order; closure doc in postmortem step
+- `DEV_RUNBOOK_TEMPLATE` — same-day re-run + post-bot deploy rows
+- `/execute_plan` — same-day pipeline warning; post-digest Pages verification
+
+---
+
 **How to add entries:** After `/postmortem` in an instantiated app, open a PR to [project-genesis](https://github.com/Leftyshields/project-genesis) or append here via PR from your app repo.

--- a/docs/INSTANTIATED_APP_FEEDBACK.md
+++ b/docs/INSTANTIATED_APP_FEEDBACK.md
@@ -1,0 +1,60 @@
+# Instantiated App Feedback Log
+
+Changelog of workflow improvements derived from real app development (postmortems). Use when updating Genesis templates and Cursor commands.
+
+---
+
+## 2026-05-31 — Wallet Watcher (Transactions, EPH-20260531-H3M8)
+
+**Source:** Greenfield feature after MVP; full Genesis workflow (capture → explore → design → plan → execute → code review → QA → postmortem).
+
+### Friction observed
+
+| Area | Issue |
+|------|--------|
+| Local dev parity | Runbook referenced seed script before it existed in `package.json` |
+| Execute handoff | Feature “done” but UI empty without user-driven seed/debug |
+| Monorepo | API imported shared package from `dist/`; edits silent until rebuild |
+| Emulator lifecycle | Port conflicts, duplicate emulator instances blocked QA |
+| Planning order | `/design_decisions` before `/create_plan`; stale plan file passed gate |
+| Multi-source data | Seed + vendor API data indistinguishable until late QA |
+| QA scope | Relink, source column, subscription fixes added ad-hoc during validation |
+
+### Root cause (process)
+
+Local dev parity was documented aspirationally but not treated as part of “done.” Demoability should be a deliverable, not a QA surprise.
+
+---
+
+## 2026-06-07 — AI Tastemakers (Daily Digest, EPH-20260606-DIG1)
+
+**Source:** Greenfield instantiate → deploy (capture → explore → design → plan → execute → GitHub Actions + GitHub Pages).
+
+### Friction observed
+
+| Area | Issue |
+|------|--------|
+| External APIs | Deprecated Anthropic model ID in `.env.example` → 404 on all narrations |
+| Git | Placeholder remote `YOU/repo`; push failed until `gh repo create` |
+| GHA vs local git | Bot commit caused non-fast-forward push; needed `git pull --rebase` |
+| GitHub Pages | Root-absolute `/assets/style.css` → unstyled site on project URL |
+| MVP definition | Local CLI success treated as “done”; production URL/CSS not verified |
+| Ranking UX | Bootstrap mode surfaced mega-repos; cold-start not documented upfront |
+
+### Root cause (process)
+
+**Production parity** missing from MVP definition. Scheduled/automated products need deployment verification (secrets, GHA dispatch, public artifact) — not just local run + unit tests.
+
+### Changes incorporated into Genesis (PR `improve/tastemakers-postmortem-dig1`)
+
+- `/execute_plan` — Deployment verification gate
+- `/design_decisions` — External API identifiers; cold-start / bootstrap caveat
+- `/postmortem` — List skipped workflow phases
+- `/workflow` — Common mistakes (Pages paths, git remote, API IDs, GHA rebase, production parity)
+- `DEV_RUNBOOK_TEMPLATE` — Scheduled job section; script integrity rule
+- `docs/GITHUB_PAGES_CHECKLIST.md` — New template
+- `README.md` — Post-instantiate git + GitHub block
+
+---
+
+**How to add entries:** After `/postmortem` in an instantiated app, open a PR to [project-genesis](https://github.com/Leftyshields/project-genesis) or append here via PR from your app repo.

--- a/docs/WORKFLOW_COURSE.md
+++ b/docs/WORKFLOW_COURSE.md
@@ -1,0 +1,175 @@
+# Genesis Workflow Course
+
+A practical guide to the **Creator → Genesis → Ship** loop in instantiated apps. Use with [.cursor/commands/workflow.md](../.cursor/commands/workflow.md) and Cursor slash commands.
+
+---
+
+## Who this is for
+
+- Humans shipping features with AI agents in a Genesis-instantiated repo
+- Contributors improving Genesis templates after postmortems
+
+**Not covered here:** Organism runtime (`lib/`, `scripts/build.js`) — see [BLUEPRINT.md](BLUEPRINT.md).
+
+---
+
+## The loop (one feature)
+
+```mermaid
+flowchart LR
+  A["/capture_issue"] --> B["/explore"]
+  B --> C["/create_plan"]
+  C --> D["/design_decisions"]
+  D --> E["/pre_implementation_checklist"]
+  E --> F["/execute_plan"]
+  F --> G["/code_review"]
+  G --> H["/qa_checklist"]
+  H --> I["Deploy"]
+  I --> J["/postmortem"]
+```
+
+**Flexible order:** `/design_decisions` may run before or after `/create_plan`, but **both** must exist and **`last_plan.md` issue ID must match `last_capture.md`** before `/execute_plan`.
+
+---
+
+## Phase 1 — Planning (do not skip the plan file)
+
+| Command | Output | Common mistake |
+|---------|--------|----------------|
+| `/capture_issue` | `.ai/context/last_capture.md` | Vague desired behavior |
+| `/explore` | `.ai/context/last_explore.md` | Skipping constraints / non-goals |
+| `/create_plan` | `.ai/context/last_plan.md` | **Reusing closed issue’s `execution_plan.md`** |
+| `/design_decisions` | `.ai/context/design_decisions.md` | Missing rendering strategy for formatted output |
+| `/pre_implementation_checklist` | Gate before code | Proceeding with mismatched issue IDs |
+
+**Rule:** Follow-on issues (v1.1, copy tweaks) still need a **new** plan file — not the previous closure’s plan.
+
+---
+
+## Phase 2 — Implementation
+
+`/execute_plan` ends with two verification gates when applicable:
+
+1. **Local dev verification** — tests, build, runbook, happy-path commands
+2. **Deployment verification** — secrets, GHA dispatch, public URL, Pages CSS (see [GITHUB_PAGES_CHECKLIST.md](GITHUB_PAGES_CHECKLIST.md))
+
+Stop and ask if you discover missing specs — do not silently expand scope.
+
+---
+
+## Phase 3 — Quality (standard, not optional for milestones)
+
+| Command | Agent | Human |
+|---------|-------|-------|
+| `/code_review` | Security, architecture, correctness | — |
+| `/qa_checklist` | `npm test`, build | Happy path, edge cases, UX |
+| `/security_scan` | Optional | Auth, secrets, sensitive data |
+| `/peer_review` | Optional | High-impact changes |
+
+**Anti-pattern:** “Small copy change” → skip QA → ship → discover production-only behavior.
+
+---
+
+## Phase 4 — Ship & reflect
+
+1. `git add -A && git commit && git push` (user terminal if agent lacks remote)
+2. Verify automation artifacts on `main`
+3. `/postmortem` → `.ai/context/postmortem_*.md` + `docs/CLOSURE_*.md`
+4. Feed lessons to Genesis via PR or [INSTANTIATED_APP_FEEDBACK.md](INSTANTIATED_APP_FEEDBACK.md)
+
+---
+
+## Case study A — Greenfield scheduled product (AI Tastemakers DIG1)
+
+**Profile:** New repo from `instantiate.sh`, daily GitHub Actions job, GitHub Pages.
+
+| Lesson | What went wrong | Fix in workflow |
+|--------|-----------------|-----------------|
+| Production parity | “Done” = local CLI only | Deployment verification gate in `/execute_plan` |
+| Pages CSS | `/assets/style.css` on project site | Relative paths checklist |
+| GHA vs local git | Bot commit blocked push | `git pull --rebase` in common mistakes |
+| External APIs | Stale model ID in `.env.example` | Verify provider IDs at implement time |
+
+**Takeaway:** For cron/GHA products, MVP includes **one successful manual workflow dispatch** and **public URL check**.
+
+---
+
+## Case study B — Follow-on copy change (AI Tastemakers COPY)
+
+**Profile:** Prompt + homepage copy only; no intended pipeline changes.
+
+| Lesson | What went wrong | Fix in workflow |
+|--------|-----------------|-----------------|
+| Plan hygiene | `design_decisions` before `create_plan`; stale DIG1 plan | Enforce `last_plan.md` match early |
+| Verification | Local same-day `npm run digest` to preview format | **Same-day re-run is not idempotent** |
+| Scope blur | Soft-dedup reshuffled rankings; enrich drifted stars | Document provenance; prefer tests + GHA |
+| Deploy chain | Digest bot commit did not update Pages | Verify or dispatch Pages after digest |
+
+**Takeaway:** When output is **dated pipeline artifacts** (`briefings/YYYY-MM-DD/`), verification strategy must be explicit in explore/design:
+
+| Change type | Preferred verification |
+|-------------|------------------------|
+| Prompt / format only | `npm run test:digest` + GHA dispatch |
+| Homepage / static copy | `npm run build:pages` + Pages deploy |
+| Ranking / discovery logic | Controlled local run or fixture date |
+
+See [Scheduled pipeline idempotency](#scheduled-pipeline-idempotency) below.
+
+---
+
+## Scheduled pipeline idempotency
+
+Applies to jobs that write **date-stamped folders** (digests, reports, snapshots).
+
+**Same calendar day re-run risks:**
+
+1. **Soft-dedup** — Prior run’s repos in `briefings/YYYY-MM-DD/` get penalized → ranking reshuffle
+2. **Live API refresh** — Enrich step may overwrite snapshot star counts (±1 drift)
+3. **Committed artifact churn** — Noisy git history, confused production state
+
+**Safe patterns:**
+
+- Unit/integration tests with mocked GitHub + Claude
+- GHA `workflow_dispatch` as production truth
+- If local re-run required: document `excludeDate` / provenance rules in app `ARCHITECTURE.md`
+
+**Symptom → fix** rows belong in `docs/DEV_RUNBOOK.md` — see [DEV_RUNBOOK_TEMPLATE.md](DEV_RUNBOOK_TEMPLATE.md).
+
+---
+
+## Post-digest / post-bot deploy checklist
+
+After a GitHub Actions bot commits artifacts:
+
+1. `git pull` locally before further pushes
+2. `gh run list --workflow="Deploy GitHub Pages"` (or your deploy workflow)
+3. If missing: `gh workflow run "Deploy GitHub Pages"`
+4. Hard-refresh public URL — new content + CSS
+
+---
+
+## Quick start path (small fixes)
+
+For trivial bugs with clear scope:
+
+1. `/capture_issue`
+2. `/execute_plan` (mini plan in chat or `last_plan.md`)
+3. `/code_review`
+4. Deploy
+5. `/postmortem` if process lesson learned
+
+Still run tests. Still verify deploy if the fix touches customer-facing output.
+
+---
+
+## Contributing improvements
+
+After `/postmortem` in any instantiated app:
+
+1. Append to app `docs/INSTANTIATED_APP_FEEDBACK.md`
+2. Open PR to [project-genesis](https://github.com/Leftyshields/project-genesis) updating templates/commands
+3. Reference case study in this course if the lesson is reusable
+
+---
+
+**Last updated:** 2026-06-07 (EPH-20260607-COPY postmortem)


### PR DESCRIPTION
## Summary
- Adds `docs/WORKFLOW_COURSE.md` with greenfield (DIG1) and follow-on copy (COPY) case studies
- Documents scheduled pipeline idempotency: same-day re-run risks, verification strategy, post-bot deploy checks
- Updates workflow commands, runbook template, and instantiated app feedback from EPH-20260607-COPY postmortem

Extends `improve/tastemakers-postmortem-dig1` (DIG1 lessons retained).

## Test plan
- [ ] Review WORKFLOW_COURSE.md narrative against AI Tastemakers session
- [ ] Re-instantiate or diff `instantiate.sh` output for new template files
- [ ] Merge after `improve/tastemakers-postmortem-dig1` or rebase onto main


Made with [Cursor](https://cursor.com)